### PR TITLE
Small fixes in assets

### DIFF
--- a/assets/3dmodels-cc0.json
+++ b/assets/3dmodels-cc0.json
@@ -6,7 +6,7 @@
     "hero": "", 
     "thumb": ""
   }, 
-  "library_url": "https://www.3dmodelscc0.com/", 
+  "library_url": "", 
   "license": "CC0", 
   "name": "3DModelsCC0", 
   "platforms": [
@@ -14,10 +14,10 @@
     "windows", 
     "linux"
   ], 
-  "project_url": "https://www.3dmodelscc0.com/", 
+  "project_url": "", 
   "tags": [
     "art assets"
   ], 
   "timestamp": 1656236297.0, 
-  "website_url": "https://www.3dmodelscc0.com/"
+  "website_url": "https://www.3dmodelscc0.com"
 }

--- a/assets/admob-defold.json
+++ b/assets/admob-defold.json
@@ -22,5 +22,5 @@
     "Platform"
   ],
   "timestamp": 1621434870.0,
-  "website_url": "https://defold.com/extension-admob/"
+  "website_url": "https://defold.com/extension-admob"
 }

--- a/assets/admob.json
+++ b/assets/admob.json
@@ -24,5 +24,5 @@
     "Monetization"
   ],
   "timestamp": 1567163518.0,
-  "website_url": "http://docs.spiralcodestudio.com/extension/admob"
+  "website_url": "https://docs.spiralcodestudio.com/extension/admob"
 }

--- a/assets/alienworld.json
+++ b/assets/alienworld.json
@@ -25,5 +25,5 @@
     "Template projects"
   ],
   "timestamp": 1567163518.0,
-  "website_url": "http://ansimuz.com/"
+  "website_url": "http://ansimuz.com"
 }

--- a/assets/colyseus.json
+++ b/assets/colyseus.json
@@ -24,5 +24,5 @@
     "Platform"
   ],
   "timestamp": 1567163518.0,
-  "website_url": "http://colyseus.io/"
+  "website_url": "https://colyseus.io"
 }

--- a/assets/daabbcc.json
+++ b/assets/daabbcc.json
@@ -23,5 +23,5 @@
     "Physics"
   ],
   "timestamp": 1567163518.0,
-  "website_url": "http://www.selimanac.space/"
+  "website_url": ""
 }

--- a/assets/debeat.json
+++ b/assets/debeat.json
@@ -23,5 +23,5 @@
     "Audio"
   ],
   "timestamp": 1567163518.0,
-  "website_url": "https://adamwestman.github.io/Debeat/"
+  "website_url": ""
 }

--- a/assets/defarc.json
+++ b/assets/defarc.json
@@ -27,5 +27,5 @@
     "util"
   ],
   "timestamp": 1651654429.0,
-  "website_url": "https://github.com/paweljarosz/defarc"
+  "website_url": ""
 }

--- a/assets/defbuild.json
+++ b/assets/defbuild.json
@@ -19,5 +19,5 @@
     "System"
   ],
   "timestamp": 1578955020.0,
-  "website_url": "https://github.com/Jerakin/DefBuild"
+  "website_url": ""
 }

--- a/assets/defluid.json
+++ b/assets/defluid.json
@@ -7,7 +7,7 @@
     "hero": "defluid-hero.png", 
     "thumb": "defluid-thumb.png"
   }, 
-  "library_url": "https://github.com/paweljarosz/defluid", 
+  "library_url": "https://github.com/paweljarosz/defluid/archive/master.zip", 
   "license": "GNU General Public License v3.0", 
   "name": "DEFLUID", 
   "platforms": [
@@ -18,12 +18,12 @@
     "Linux", 
     "HTML5"
   ], 
-  "project_url": "", 
+  "project_url": "https://github.com/paweljarosz/defluid", 
   "tags": [
     "Physics", 
     "Rendering", 
     "Shaders"
   ], 
   "timestamp": 1567163518.0, 
-  "website_url": "https://github.com/paweljarosz/defluid"
+  "website_url": ""
 }

--- a/assets/defold-box2d.json
+++ b/assets/defold-box2d.json
@@ -1,7 +1,7 @@
 {
   "author": "d954mas",
   "description": "Box2D Lua bindings for Defold Game Engine.",
-  "forum_url": "https://github.com/d954mas/defold-box2d/archive/refs/tags/0.8.zip",
+  "forum_url": "https://forum.defold.com/t/defold-box2d-box2d-extension/68720",
   "images": {
     "hero": "defold-box2d-hero.png",
     "thumb": "defold-box2d-thumb.png"

--- a/assets/defold-mobilehtml5-typing.json
+++ b/assets/defold-mobilehtml5-typing.json
@@ -6,7 +6,7 @@
     "hero": "",
     "thumb": ""
   },
-  "library_url": " https://github.com/mchlkpng/defold-mobilehtml5-typing/archive/main.zip",
+  "library_url": "https://github.com/mchlkpng/defold-mobilehtml5-typing/archive/main.zip",
   "license": "MIT License",
   "name": "Mobile HTML5 Text Keyboard Input",
   "platforms": [

--- a/assets/defold-parser.json
+++ b/assets/defold-parser.json
@@ -6,7 +6,7 @@
 	"library_url": "",
 	"project_url": "https://github.com/Insality/defold-parser",
 	"forum_url": "https://forum.defold.com/t/defold-parser-node-module/71903",
-	"website_url": "https://github.com/Insality/defold-parser",
+	"website_url": "",
 	"platforms": [
 		"android",
 		"ios",

--- a/assets/dicebag.json
+++ b/assets/dicebag.json
@@ -17,7 +17,7 @@
     "linux", 
     "html5"
   ], 
-  "project_url": "https://github.com/8bitskull/dicebag/tree/master", 
+  "project_url": "https://github.com/8bitskull/dicebag", 
   "tags": [
     "game mechanic", 
     "math", 

--- a/assets/emthree.json
+++ b/assets/emthree.json
@@ -24,5 +24,5 @@
     "Game mechanic"
   ],
   "timestamp": 1567163518.0,
-  "website_url": "https://britzl.github.io/Emthree/"
+  "website_url": "https://britzl.github.io/Emthree"
 }

--- a/assets/endlessrunner.json
+++ b/assets/endlessrunner.json
@@ -24,5 +24,5 @@
     "Template projects"
   ],
   "timestamp": 1567163518.0,
-  "website_url": "https://www.defold.com/tutorials/getting-started/"
+  "website_url": "https://www.defold.com/tutorials/getting-started"
 }

--- a/assets/enhance.json
+++ b/assets/enhance.json
@@ -27,5 +27,5 @@
     "Monetization"
   ],
   "timestamp": 1567163518.0,
-  "website_url": "https://enhance.co/"
+  "website_url": "https://enhance.co"
 }

--- a/assets/extensiondirectories.json
+++ b/assets/extensiondirectories.json
@@ -23,5 +23,5 @@
     "System"
   ],
   "timestamp": 1567163518.0,
-  "website_url": "https://docs.spiralcodestudio.com/"
+  "website_url": "https://docs.spiralcodestudio.com"
 }

--- a/assets/facebook.json
+++ b/assets/facebook.json
@@ -20,5 +20,5 @@
     "Platform"
   ],
   "timestamp": 1573202520.0,
-  "website_url": "https://defold.com/manuals/facebook/"
+  "website_url": "https://defold.com/manuals/facebook"
 }

--- a/assets/gameanalytics.json
+++ b/assets/gameanalytics.json
@@ -23,5 +23,5 @@
     "Analytics"
   ],
   "timestamp": 1567163518.0,
-  "website_url": "https://gameanalytics.com/"
+  "website_url": "https://gameanalytics.com"
 }

--- a/assets/googleplayinstant.json
+++ b/assets/googleplayinstant.json
@@ -12,10 +12,10 @@
   "platforms": [
     "Android"
   ], 
-  "project_url": "https://github.com/defold/extension-googleplayinstant/", 
+  "project_url": "https://github.com/defold/extension-googleplayinstant", 
   "tags": [
     "Platform"
   ], 
   "timestamp": 1603712978.0, 
-  "website_url": "https://defold.com/extension-googleplayinstant/"
+  "website_url": "https://defold.com/extension-googleplayinstant"
 }

--- a/assets/iac.json
+++ b/assets/iac.json
@@ -19,5 +19,5 @@
     "System"
   ],
   "timestamp": 1571641220.0,
-  "website_url": "https://defold.com/manuals/iac/"
+  "website_url": "https://defold.com/manuals/iac"
 }

--- a/assets/iap.json
+++ b/assets/iap.json
@@ -20,5 +20,5 @@
     "Monetization"
   ],
   "timestamp": 1571602170.0,
-  "website_url": "https://defold.com/extension-iap/"
+  "website_url": "https://defold.com/extension-iap"
 }

--- a/assets/illumination.json
+++ b/assets/illumination.json
@@ -1,7 +1,7 @@
 {
   "author": "Roman Silin",
   "description": "Ready-to-use forward shading lighting for 3D games. Just set the provided material to your mesh and place light sources on the scene.",
-  "forum_url": "https://forum.defold.com/t/illumination-ready-to-use-forward-shading-lighting-for-3d-games/71465/2",
+  "forum_url": "https://forum.defold.com/t/illumination-ready-to-use-forward-shading-lighting-for-3d-games/71465",
   "images": {
     "hero": "illumination-hero.jpeg",
     "thumb": "illumination-thumb.jpeg"

--- a/assets/kenney.json
+++ b/assets/kenney.json
@@ -18,7 +18,7 @@
     "Linux", 
     "HTML5"
   ], 
-  "project_url": "https://kenney.nl/assets", 
+  "project_url": "", 
   "tags": [
     "Art assets", 
     "Audio", 

--- a/assets/kenney.json
+++ b/assets/kenney.json
@@ -25,5 +25,5 @@
     "Fonts"
   ], 
   "timestamp": 1586074653.0, 
-  "website_url": "http://kenney.nl/"
+  "website_url": "http://kenney.nl"
 }

--- a/assets/magiclinker.json
+++ b/assets/magiclinker.json
@@ -24,5 +24,5 @@
     "Game mechanic"
   ],
   "timestamp": 1567163518.0,
-  "website_url": "https://www.defold.com/tutorials/magic-link/"
+  "website_url": "https://www.defold.com/tutorials/magic-link"
 }

--- a/assets/nakama.json
+++ b/assets/nakama.json
@@ -26,5 +26,5 @@
     "Achievements"
   ],
   "timestamp": 1590661297.0,
-  "website_url": "https://heroiclabs.com/"
+  "website_url": "https://heroiclabs.com"
 }

--- a/assets/nativetext.json
+++ b/assets/nativetext.json
@@ -23,5 +23,5 @@
     "Rendering"
   ],
   "timestamp": 1583224177.0,
-  "website_url": "https://docs.spiralcodestudio.com/"
+  "website_url": "https://docs.spiralcodestudio.com"
 }

--- a/assets/openal.json
+++ b/assets/openal.json
@@ -23,5 +23,5 @@
     "Audio"
   ],
   "timestamp": 1567163518.0,
-  "website_url": "http://spiralcodestudio.com/"
+  "website_url": "http://spiralcodestudio.com"
 }

--- a/assets/openal.json
+++ b/assets/openal.json
@@ -23,5 +23,5 @@
     "Audio"
   ],
   "timestamp": 1567163518.0,
-  "website_url": "http://spiralcodestudio.com"
+  "website_url": "https://spiralcodestudio.com"
 }

--- a/assets/pigeon.json
+++ b/assets/pigeon.json
@@ -17,7 +17,7 @@
     "Linux",
     "HTML5"
   ],
-  "project_url": "https://github.com/paweljarosz/pigeon/",
+  "project_url": "https://github.com/paweljarosz/pigeon",
   "tags": [
     "System"
   ],

--- a/assets/platformertutorial.json
+++ b/assets/platformertutorial.json
@@ -23,5 +23,5 @@
     "Template projects"
   ],
   "timestamp": 1567163518.0,
-  "website_url": "https://www.defold.com/tutorials/platformer/"
+  "website_url": "https://www.defold.com/tutorials/platformer"
 }

--- a/assets/platypus.json
+++ b/assets/platypus.json
@@ -24,5 +24,5 @@
     "Game mechanic"
   ],
   "timestamp": 1567163518.0,
-  "website_url": "https://britzl.github.io/Platypus/"
+  "website_url": "https://britzl.github.io/Platypus"
 }

--- a/assets/playfabsdk.json
+++ b/assets/playfabsdk.json
@@ -25,5 +25,5 @@
     "Platform"
   ],
   "timestamp": 1567163518.0,
-  "website_url": "https://playfab.com/"
+  "website_url": "https://playfab.com"
 }

--- a/assets/rive.json
+++ b/assets/rive.json
@@ -17,10 +17,10 @@
     "macOS",
     "HTML5"
   ],
-  "project_url": "https://github.com/defold/extension-rive/",
+  "project_url": "https://github.com/defold/extension-rive",
   "tags": [
     "Lua"
   ],
   "timestamp": 1681228502.0,
-  "website_url": "https://defold.com/extension-rive/"
+  "website_url": "https://defold.com/extension-rive"
 }

--- a/assets/slasherprototype.json
+++ b/assets/slasherprototype.json
@@ -21,5 +21,5 @@
     "Template projects"
   ],
   "timestamp": 1567163518.0,
-  "website_url": "https://dragosha.github.io/slasher-prototype/"
+  "website_url": "https://dragosha.github.io/slasher-prototype"
 }

--- a/assets/tiled.json
+++ b/assets/tiled.json
@@ -20,5 +20,5 @@
     "Tools"
   ],
   "timestamp": 1573623163.0,
-  "website_url": "https://www.mapeditor.org/"
+  "website_url": "https://www.mapeditor.org"
 }

--- a/assets/tinyhttp.json
+++ b/assets/tinyhttp.json
@@ -1,7 +1,7 @@
 {
   "author": "Selim Ana\u00e7", 
   "description": "Simple http server and client native extension", 
-  "forum_url": "https://forum.defold.com/t/tiny-http-simple-http-server-and-client/", 
+  "forum_url": "https://forum.defold.com/t/tiny-http-simple-http-server-and-client", 
   "images": {
     "hero": "https://user-images.githubusercontent.com/1324635/67929843-6bfc2700-fbcf-11e9-8d67-168f1bfe4151.png", 
     "thumb": "https://user-images.githubusercontent.com/1324635/67929852-728a9e80-fbcf-11e9-8ba8-90d8559f728d.png"
@@ -16,10 +16,10 @@
     "Windows", 
     "Linux"
   ], 
-  "project_url": "https://github.com/selimanac/defold-tiny-http/", 
+  "project_url": "https://github.com/selimanac/defold-tiny-http", 
   "tags": [
     "Network"
   ], 
   "timestamp": 1572816167.0, 
-  "website_url": "https://selimanac.github.io/"
+  "website_url": "https://selimanac.github.io"
 }

--- a/assets/warbattlesassetpack.json
+++ b/assets/warbattlesassetpack.json
@@ -26,5 +26,5 @@
     "Template projects"
   ],
   "timestamp": 1567163518.0,
-  "website_url": "http://ansimuz.com/"
+  "website_url": "http://ansimuz.com"
 }

--- a/assets/websocket.json
+++ b/assets/websocket.json
@@ -23,5 +23,5 @@
     "Network"
   ],
   "timestamp": 1604098714.0,
-  "website_url": "https://defold.com/extension-websocket/"
+  "website_url": "https://defold.com/extension-websocket"
 }

--- a/assets/whdefrouter.json
+++ b/assets/whdefrouter.json
@@ -23,5 +23,5 @@
     "GUI"
   ],
   "timestamp": 1567163518.0,
-  "website_url": "https://wisehedgehog.studio/"
+  "website_url": "https://wisehedgehog.studio"
 }

--- a/assets/wortal.json
+++ b/assets/wortal.json
@@ -21,5 +21,5 @@
     "platform"
   ],
   "timestamp": 1664495798.0,
-  "website_url": "https://html5gameportal.com/"
+  "website_url": "https://html5gameportal.com"
 }

--- a/assets/yoga.json
+++ b/assets/yoga.json
@@ -24,5 +24,5 @@
     "rendering"
   ],
   "timestamp": 1682499193.0,
-  "website_url": "https://github.com/farism/defold-yoga"
+  "website_url": ""
 }


### PR DESCRIPTION
Hi @britzl 
I noticed that some github assets from the asset portal are missing github stars. This seems to happen if "project_url" deviates from the pattern "github.com/username/assetname". Even if there is an extra "/" at the end. So I tried to fix this and made some other small changes. If I'm wrong, please reject this pull request :)