### PR TITLE
Add donation options buttons

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-asset.md
+++ b/.github/ISSUE_TEMPLATE/new-asset.md
@@ -42,6 +42,7 @@ assignees: ''
     "forum_url": "",
     "project_url": "",
     "website_url": "",
+    "external_actions": [],
     "platforms": [
         "iOS",
         "Android",
@@ -65,6 +66,7 @@ assignees: ''
 * `forum_url` - (OPTIONAL) URL to a Defold forum post for discussions about the asset.
 * `project_url` - (OPTIONAL) URL to a site with additional information about the asset (eg <https://github.com/britzl/monarch>).
 * `website_url` - (OPTIONAL) URL to a site with additional information.
+* `external_actions` - (OPTIONAL) Up to three external creator links. Each entry must contain a `type` (`purchase` or `support`), a short `label`, and an allowlisted HTTPS `url`. Defold only links to the external platform and does not process payments.
 * `tags` - (REQUIRED) One or more tags to categorize the asset.
 * `platforms` - (REQUIRED) One or more platforms supported by the asset.
 * `images` - (OPTIONAL) Filenames of images that can be used when presenting the asset.

--- a/.github/workflows/trigger-site-rebuild.yml
+++ b/.github/workflows/trigger-site-rebuild.yml
@@ -1,6 +1,6 @@
 name: Trigger site rebuild
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
     build:
@@ -26,6 +26,8 @@ jobs:
         },
         { name: 'Install Python', uses: actions/setup-python@v4, with: { python-version: 3.10.5, architecture: x64 } },
         { name: 'Install Requests', run: 'pip install --user requests' },
+        { name: 'Validate asset metadata', run: 'python update.py validate' },
+        { name: 'Test asset metadata validator', run: 'python -m unittest discover -s tests -v' },
         { name: 'Update dates', if: github.ref == 'refs/heads/master', run: 'python update.py --githubtoken=${{ secrets.SERVICES_GITHUB_TOKEN }} dates' },
         { name: 'Update stars', if: github.ref == 'refs/heads/master', run: 'python update.py --githubtoken=${{ secrets.SERVICES_GITHUB_TOKEN }} starcount' },
         { name: 'Update releases', if: github.ref == 'refs/heads/master', run: 'python update.py --githubtoken=${{ secrets.SERVICES_GITHUB_TOKEN }} releases' },

--- a/.github/workflows/trigger-site-rebuild.yml
+++ b/.github/workflows/trigger-site-rebuild.yml
@@ -1,6 +1,6 @@
 name: Trigger site rebuild
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
     build:

--- a/.github/workflows/update_github_info.yml
+++ b/.github/workflows/update_github_info.yml
@@ -14,6 +14,7 @@ jobs:
             { name: 'Checkout', uses: actions/checkout@v2, with: { fetch-depth: 1 } },
             { name: 'Install Python', uses: actions/setup-python@v4, with: { python-version: 3.10.5, architecture: x64 } },
             { name: 'Install Requests', run: 'pip install --user requests' },
+            { name: 'Validate asset metadata', run: 'python update.py validate' },
             { name: 'Update stars', run: 'python update.py --githubtoken=${{ secrets.SERVICES_GITHUB_TOKEN }} starcount' },
             { name: 'Update releases', run: 'python update.py --githubtoken=${{ secrets.SERVICES_GITHUB_TOKEN }} releases' },
             { name: 'Detect Defold libraries', run: 'python update.py --githubtoken=${{ secrets.SERVICES_GITHUB_TOKEN }} library' },

--- a/README.md
+++ b/README.md
@@ -7,5 +7,34 @@ Submit a new asset for inclusion in this collection either via the `Submit Asset
 ## Updating an asset
 You can update an asset by modifying its metadata file. The metadata for all assets can be found in the `assets` folder of this repository. Once you are happy with the changes please submit a pull request.
 
+## External creator actions
+Assets can optionally include up to three external creator action links. These links are rendered on the asset detail page on the Defold website. Defold only links to third-party platforms and does not process payments, manage purchases, provide refunds, or verify license entitlement.
+
+Example:
+
+```json
+"external_actions": [
+  {
+    "type": "purchase",
+    "label": "Purchase commercial license",
+    "url": "https://github.com/sponsors/creator?frequency=one-time"
+  },
+  {
+    "type": "support",
+    "label": "Support on Ko-fi",
+    "url": "https://ko-fi.com/creator"
+  }
+]
+```
+
+Supported `type` values are:
+
+* `purchase` for a purchase, paid download, or commercial license.
+* `support` for an optional donation or sponsorship which does not itself describe a purchase.
+
+Each action must contain only `type`, `label`, and `url`. The label must be 50 characters or fewer, and URLs must use `https://`.
+
+Allowed external action destinations are itch.io, Patreon, Ko-fi, PayPal, Stripe Checkout or Payment Links, Gumroad, GitHub Sponsors, and Open Collective. Asset authors are responsible for keeping the label, destination, pricing, and licensing information accurate. Run `python3 update.py validate` before submitting a pull request to check the metadata.
+
 ## Images
 Each asset has a thumbnail image and a hero image. The thumbnail image is a rectangular image with a maximum resolution of 570x380 piexels. The hero image is a wide image with a maximum resolution of 2400x666 pixels. If you submit smaller images, please make sure to maintain the correct aspect ratio.

--- a/assets/defold-graph-pathfinder.json
+++ b/assets/defold-graph-pathfinder.json
@@ -1,6 +1,13 @@
 {
   "author": "Selim Anaç",
-  "description": "A high-performance A* pathfinding library written in C++11, designed for real-time games and simulations with hundreds to thousands of moving objects. Built with a focus on performance, using flat array data structures and advanced caching mechanisms.",
+  "description": "A high-performance A* pathfinding library written in C++11 for real-time games and simulations. It is free for personal, educational, experimental, and completely non-monetized projects. Any monetized use requires at least a one-time $10 USD GitHub Sponsors payment per product title and providing project details to the author; monthly sponsorship is also accepted. The software is closed-source under a custom license.",
+  "external_actions": [
+    {
+      "label": "Commercial license payment",
+      "type": "purchase",
+      "url": "https://github.com/sponsors/selimanac?frequency=one-time"
+    }
+  ],
   "id": "defold-graph-pathfinder",
   "images": {
     "hero": "graph-pathfinder-hero.jpg",
@@ -8,7 +15,7 @@
   },
   "isDefoldLibrary": true,
   "library_url": "https://github.com/selimanac/defold-graph-pathfinder/archive/refs/heads/main.zip",
-  "license": "Custom License",
+  "license": "Custom License (free non-monetized; paid per commercial title)",
   "name": "A* Graph Pathfinding",
   "platforms": [
     "iOS",

--- a/tests/test_external_actions.py
+++ b/tests/test_external_actions.py
@@ -1,0 +1,100 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+REPOSITORY_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+UPDATE_SCRIPT = os.path.join(REPOSITORY_ROOT, "update.py")
+
+
+class ExternalActionsValidationTest(unittest.TestCase):
+    def run_validator(self, external_actions):
+        asset = {
+            "name": "Test asset",
+            "external_actions": external_actions,
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            assets_directory = os.path.join(directory, "assets")
+            os.mkdir(assets_directory)
+            with open(os.path.join(assets_directory, "test.json"), "w", encoding="utf-8") as asset_file:
+                json.dump(asset, asset_file)
+            return subprocess.run(
+                [sys.executable, UPDATE_SCRIPT, "validate"],
+                cwd=directory,
+                capture_output=True,
+                text=True,
+            )
+
+    def test_accepts_purchase_through_github_sponsors(self):
+        result = self.run_validator([
+            {
+                "type": "purchase",
+                "label": "Purchase commercial license",
+                "url": "https://github.com/sponsors/creator?frequency=one-time",
+            }
+        ])
+
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+
+    def test_accepts_support_through_allowlisted_platform(self):
+        result = self.run_validator([
+            {
+                "type": "support",
+                "label": "Support on Ko-fi",
+                "url": "https://ko-fi.com/creator",
+            }
+        ])
+
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+
+    def test_rejects_non_string_values_without_traceback(self):
+        result = self.run_validator([
+            {
+                "type": 123,
+                "label": ["Purchase"],
+                "url": {"host": "github.com"},
+            }
+        ])
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("type must be a string", result.stdout)
+        self.assertIn("label must be a string", result.stdout)
+        self.assertIn("URL must be a string", result.stdout)
+        self.assertNotIn("Traceback", result.stdout + result.stderr)
+
+    def test_rejects_general_github_and_unallowlisted_links(self):
+        for url in (
+            "https://github.com/creator/project",
+            "https://pages.github.com/sponsors/creator",
+            "https://example.com/checkout",
+        ):
+            with self.subTest(url=url):
+                result = self.run_validator([
+                    {
+                        "type": "purchase",
+                        "label": "Purchase asset",
+                        "url": url,
+                    }
+                ])
+
+                self.assertNotEqual(0, result.returncode)
+                self.assertIn("not an allowed creator action", result.stdout)
+
+    def test_rejects_unsafe_url_characters(self):
+        result = self.run_validator([
+            {
+                "type": "purchase",
+                "label": "Purchase asset",
+                "url": "https://github.com/sponsors/creator\" onclick=\"alert(1)",
+            }
+        ])
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("URL contains unsafe characters", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/update.py
+++ b/update.py
@@ -84,6 +84,154 @@ def find_files(root_dir, file_pattern):
     return matches
 
 
+EXTERNAL_ACTION_TYPES = set(["purchase", "support"])
+EXTERNAL_ACTION_FIELDS = set(["type", "label", "url"])
+EXTERNAL_ACTION_HOSTS = [
+    "itch.io",
+    "patreon.com",
+    "ko-fi.com",
+    "paypal.com",
+    "paypal.me",
+    "buy.stripe.com",
+    "checkout.stripe.com",
+    "gumroad.com",
+    "github.com",
+    "opencollective.com",
+]
+EXTERNAL_ACTION_BLOCKED_LABELS = [
+    "official defold purchase",
+    "official defold checkout",
+    "defold checkout",
+]
+
+
+def external_action_host_allowed(host):
+    host = (host or "").lower().rstrip(".")
+    if host.startswith("www."):
+        host = host[4:]
+    for allowed_host in EXTERNAL_ACTION_HOSTS:
+        if host == allowed_host:
+            return True
+        if allowed_host != "github.com" and host.endswith("." + allowed_host):
+            return True
+    return False
+
+
+def external_action_url_allowed(parsed_url):
+    host = (parsed_url.hostname or "").lower().rstrip(".")
+    if host.startswith("www."):
+        host = host[4:]
+    if not external_action_host_allowed(host):
+        return False
+
+    # GitHub links are allowed specifically for GitHub Sponsors. General project
+    # links already have dedicated project_url and website_url asset fields.
+    if host == "github.com":
+        path_parts = parsed_url.path.strip("/").split("/")
+        return len(path_parts) >= 2 and path_parts[0].lower() == "sponsors" and bool(path_parts[1])
+
+    return True
+
+
+def validate_external_actions():
+    print("Validating external asset actions")
+    errors = []
+    for filename in sorted(find_files("assets", "*.json")):
+        asset_id = os.path.basename(filename).replace(".json", "")
+        asset = read_as_json(filename)
+        if asset is None:
+            errors.append("{}: could not read asset JSON".format(asset_id))
+            continue
+        if not isinstance(asset, dict):
+            errors.append("{}: asset JSON must be an object".format(asset_id))
+            continue
+
+        if "external_actions" not in asset:
+            continue
+        external_actions = asset["external_actions"]
+        if not isinstance(external_actions, list):
+            errors.append("{}: external_actions must be an array".format(asset_id))
+            continue
+        if len(external_actions) > 3:
+            errors.append("{}: external_actions can contain at most 3 entries".format(asset_id))
+
+        for index, action in enumerate(external_actions):
+            label = "{} external_actions[{}]".format(asset_id, index)
+            if not isinstance(action, dict):
+                errors.append("{} must be an object".format(label))
+                continue
+
+            unexpected_fields = set(action.keys()) - EXTERNAL_ACTION_FIELDS
+            if unexpected_fields:
+                errors.append("{} has unsupported fields: {}".format(
+                    label, ", ".join(sorted(unexpected_fields))))
+
+            action_type = action.get("type")
+            if not isinstance(action_type, str):
+                errors.append("{} type must be a string".format(label))
+            elif action_type not in EXTERNAL_ACTION_TYPES:
+                errors.append("{} has unsupported type: {}".format(label, action.get("type")))
+
+            action_label = action.get("label")
+            if not isinstance(action_label, str):
+                errors.append("{} label must be a string".format(label))
+            elif not action_label.strip():
+                errors.append("{} must have a label".format(label))
+            elif action_label != action_label.strip():
+                errors.append("{} label must not have leading or trailing whitespace".format(label))
+            elif len(action_label) > 50:
+                errors.append("{} label must be 50 characters or fewer".format(label))
+            elif any(ord(char) < 32 or ord(char) == 127 for char in action_label):
+                errors.append("{} label must not contain control characters".format(label))
+            elif action_label.lower() in EXTERNAL_ACTION_BLOCKED_LABELS:
+                errors.append("{} label is misleading: {}".format(label, action_label))
+
+            action_url = action.get("url")
+            if not isinstance(action_url, str):
+                errors.append("{} URL must be a string".format(label))
+                continue
+            if not action_url.strip():
+                errors.append("{} must have a URL".format(label))
+                continue
+            if action_url != action_url.strip():
+                errors.append("{} URL must not have leading or trailing whitespace".format(label))
+            if len(action_url) > 2048:
+                errors.append("{} URL must be 2048 characters or fewer".format(label))
+            if any(char.isspace() or ord(char) < 32 or ord(char) == 127 for char in action_url):
+                errors.append("{} URL must not contain whitespace or control characters".format(label))
+            if any(char in action_url for char in ['"', "<", ">", "\\"]):
+                errors.append("{} URL contains unsafe characters".format(label))
+
+            try:
+                parsed_url = urlparse(action_url)
+                parsed_host = parsed_url.hostname
+                parsed_port = parsed_url.port
+            except ValueError:
+                errors.append("{} URL is malformed".format(label))
+                continue
+
+            if parsed_url.scheme != "https":
+                errors.append("{} URL must use https://".format(label))
+            elif not parsed_host:
+                errors.append("{} URL must include a host".format(label))
+            elif parsed_url.username or parsed_url.password:
+                errors.append("{} URL must not contain credentials".format(label))
+            elif parsed_port not in (None, 443):
+                errors.append("{} URL must not use a custom port".format(label))
+            elif not external_action_url_allowed(parsed_url):
+                errors.append("{} URL is not an allowed creator action: {}".format(label, parsed_host))
+
+    if errors:
+        print("Invalid external asset actions:")
+        for error in errors[:50]:
+            print(" - {}".format(error))
+        if len(errors) > 50:
+            print("... and {} more".format(len(errors) - 50))
+        sys.exit(1)
+
+    print("...ok!")
+
+
 def add_creation_date_to_assets():
     print("Adding creation date to assets")
     for filename in find_files("assets", "*.json"):
@@ -147,7 +295,7 @@ def commit_changes(githubtoken):
 
 
 parser = ArgumentParser()
-parser.add_argument('commands', nargs="+", help='Commands (starcount, releases, header, dates, sanitize, library, commit, help)')
+parser.add_argument('commands', nargs="+", help='Commands (starcount, releases, header, dates, sanitize, library, validate, commit, help)')
 parser.add_argument("--githubtoken", dest="githubtoken", help="Authentication token for GitHub API and ")
 parser.add_argument("--asset", dest="asset", help="Asset id (JSON file name without .json) to limit release update")
 parser.add_argument("--limit", dest="limit", type=int, help="Limit number of releases to fetch (default depends on command)")
@@ -161,6 +309,7 @@ header = Update or initialize header.json with timestamps for changed asset JSON
 dates = Add creation date to all assets
 sanitize = Re-save all asset JSON using UTF-8 (no surrogate escapes) to avoid YAML parser issues
 library = Determine if assets are Defold libraries (adds isDefoldLibrary flag; requires --githubtoken)
+validate = Validate asset metadata that is not derived from external APIs
 commit = Commit changed files (requires --githubtoken)
 help = Show this help
 """
@@ -557,6 +706,8 @@ for command in args.commands:
         add_creation_date_to_assets()
     elif command == "library":
         update_is_defold_library_flags(args.githubtoken, asset_id=args.asset)
+    elif command == "validate":
+        validate_external_actions()
     elif command == "commit":
         commit_changes(args.githubtoken)
     else:

--- a/update.py
+++ b/update.py
@@ -53,7 +53,6 @@ def github_request(url, token):
 
 def read_as_json(filename):
     try:
-        os.chmod(filename, stat.S_IWUSR | stat.S_IWGRP | stat.S_IRUSR | stat.S_IRGRP)
         with open(filename, "r", encoding="utf-8") as f:
             decoded = json.load(f)
             return decoded


### PR DESCRIPTION
This is first part of an idea to add simple buttons for external donationpurchase/sponsorship for asset entries in the asset portal in a form of additional list of `external_actions` fields in the asset's json with some CI checks for correctness.

First asset to use this button is Graph Pathfinder.

After the data is merged, a separate PR for Defold website will be prepared to display the button in Asset Portal.